### PR TITLE
Fixed busy wait in timer_sleep implementation

### DIFF
--- a/src/devices/timer.c
+++ b/src/devices/timer.c
@@ -89,11 +89,12 @@ timer_elapsed (int64_t then)
 void
 timer_sleep (int64_t ticks) 
 {
-  int64_t start = timer_ticks ();
-
   ASSERT (intr_get_level () == INTR_ON);
-  while (timer_elapsed (start) < ticks) 
-    thread_yield ();
+  enum intr_level old_level;
+
+  old_level = intr_disable ();
+  thread_sleep(ticks);
+  intr_set_level (old_level);
 }
 
 /** Sleeps for approximately MS milliseconds.  Interrupts must be

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -89,6 +89,7 @@ struct thread
     uint8_t *stack;                     /**< Saved stack pointer. */
     int priority;                       /**< Priority. */
     struct list_elem allelem;           /**< List element for all threads list. */
+    int64_t ticks_to_sleep; 
 
     /* Shared between thread.c and synch.c. */
     struct list_elem elem;              /**< List element. */
@@ -118,6 +119,8 @@ tid_t thread_create (const char *name, int priority, thread_func *, void *);
 
 void thread_block (void);
 void thread_unblock (struct thread *);
+
+void thread_sleep (int64_t ticks);
 
 struct thread *thread_current (void);
 tid_t thread_tid (void);


### PR DESCRIPTION
1. Added new field `ticks_to_sleep` in thread structure to maintain number of ticks the thread should wait
2. Separate list was created to maintain threads waiting for specified number of CPU ticks
3. Calling timer sleep we set number of specified ticks to wait, put the thread to dedicated list and block it
4. On timer interrupt in `thread_tick` method we traverse the list of timer waiting threads, decrease `ticks_to_sleep` and awake threads having `ticks_to_sleep == 0` removing them from list.

Notes:

- there should be a way to do it without separate thread list (some other structure or conditional lock)
- there should be a way to implement without direct interrupts manipulations
- decreasing new variable on every tick is not the most efficient solution, we could play with timer-wheels data structure to maintain  timers