### PR TITLE
Implemented priority based scheduling (instead of FIFO)

### DIFF
--- a/src/threads/synch.c
+++ b/src/threads/synch.c
@@ -68,7 +68,7 @@ sema_down (struct semaphore *sema)
   old_level = intr_disable ();
   while (sema->value == 0) 
     {
-      list_push_back (&sema->waiters, &thread_current ()->elem);
+      list_insert_ordered (&sema->waiters, &thread_current ()->elem, thread_priority_higher, NULL);
       thread_block ();
     }
   sema->value--;
@@ -114,10 +114,16 @@ sema_up (struct semaphore *sema)
 
   old_level = intr_disable ();
   if (!list_empty (&sema->waiters)) 
-    thread_unblock (list_entry (list_pop_front (&sema->waiters),
-                                struct thread, elem));
+  {
+    // sort list to support case that priorities could be changed on blocked threads
+    list_sort(&sema->waiters, thread_priority_higher, NULL);
+    thread_unblock (list_entry (list_pop_front (&sema->waiters), struct thread, elem));
+  }
   sema->value++;
   intr_set_level (old_level);
+  // there is a chance that unblocked thread has higher priority,
+  // let it to be rescheduled yelding CPU on the current thread (test priority-sema)
+  thread_yield ();
 }
 
 static void sema_test_helper (void *sema_);
@@ -295,7 +301,7 @@ cond_wait (struct condition *cond, struct lock *lock)
   ASSERT (lock_held_by_current_thread (lock));
   
   sema_init (&waiter.semaphore, 0);
-  list_push_back (&cond->waiters, &waiter.elem);
+  list_insert_ordered (&cond->waiters, &waiter.elem, thread_priority_higher, NULL);
   lock_release (lock);
   sema_down (&waiter.semaphore);
   lock_acquire (lock);
@@ -316,9 +322,12 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED)
   ASSERT (!intr_context ());
   ASSERT (lock_held_by_current_thread (lock));
 
-  if (!list_empty (&cond->waiters)) 
-    sema_up (&list_entry (list_pop_front (&cond->waiters),
-                          struct semaphore_elem, elem)->semaphore);
+  if (!list_empty (&cond->waiters))
+  {
+    // sort list to support case that priorities could be changed on blocked threads
+    list_sort(&cond->waiters, thread_priority_higher, NULL);
+    sema_up (&list_entry (list_pop_front (&cond->waiters), struct semaphore_elem, elem)->semaphore);
+  }
 }
 
 /** Wakes up all threads, if any, waiting on COND (protected by

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -141,4 +141,6 @@ void thread_set_nice (int);
 int thread_get_recent_cpu (void);
 int thread_get_load_avg (void);
 
+bool thread_priority_higher (const struct list_elem *, const struct list_elem *, void *);
+
 #endif /**< threads/thread.h */


### PR DESCRIPTION
Supported:

- priority based scheduling
- preemption
- priority change
- supported synchronisation primitives
- [WIP] priority donation

The main source of ideas about the solution:
https://www.youtube.com/watch?v=myO2bs5LMak&list=PLmQBKYly8OsWiRYGn1wvjwAdbuNWOBJNf&index=3&t=930s